### PR TITLE
feat: implement replay buffer

### DIFF
--- a/dqn/replay_buffer.py
+++ b/dqn/replay_buffer.py
@@ -1,0 +1,21 @@
+import random
+from collections import deque
+
+
+class ReplayBuffer:
+    """
+    Fixed-size buffer to store experience tuples for DQN training.
+    """
+
+    def __init__(self, capacity=10000):
+        self.buffer = deque(maxlen=capacity)
+
+    def add(self, state, action, reward, next_state, done):
+        transition = (state, action, reward, next_state, done)
+        self.buffer.append(transition)
+
+    def sample(self, batch_size):
+        return random.sample(self.buffer, batch_size)
+
+    def __len__(self):
+        return len(self.buffer)

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -1,0 +1,26 @@
+from dqn.replay_buffer import ReplayBuffer
+
+
+def test_replay_buffer_add_increases_length():
+    buffer = ReplayBuffer(capacity=5)
+    buffer.add((1, 2, 3, 4), 0, 1.0, (1, 2, 3, 5), False)
+    assert len(buffer) == 1
+
+
+def test_replay_buffer_sample_returns_correct_batch_size():
+    buffer = ReplayBuffer(capacity=10)
+
+    for i in range(5):
+        buffer.add((i, i, i, i), 0, 1.0, (i + 1, i + 1, i + 1, i + 1), False)
+
+    sample = buffer.sample(3)
+    assert len(sample) == 3
+
+
+def test_replay_buffer_respects_capacity():
+    buffer = ReplayBuffer(capacity=3)
+
+    for i in range(5):
+        buffer.add((i, i, i, i), 0, 1.0, (i + 1, i + 1, i + 1, i + 1), False)
+
+    assert len(buffer) == 3


### PR DESCRIPTION
Adds replay buffer for DQN training with sampling and capacity control.
Includes unit tests for buffer behavior.
Closes #9